### PR TITLE
Fix spell images and map name

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -175,6 +175,13 @@
       </div>
     </nav>
   </div>
+  <!-- Spell search and list UI -->
+  <div id="spell-search-container" style="position:relative; z-index:1000; max-width:400px; margin:2em auto 0 auto;">
+    <button id="spellChanceInfoButton" style="margin-bottom:0.5em;" title="Spell spawn info">i</button>
+    <input id="spellSelector" type="text" placeholder="Search spells..." autocomplete="off"
+      style="width:100%; margin-bottom:0.5em;" />
+    <ul id="spellList" tabindex="0" style="width:100%;"></ul>
+  </div>
   <i id="loadingIndicator" class="bi bi-arrow-repeat loadingIndicator spinningIcon text-info"></i>
   <div id="coordinates-hover"></div>
   <div id="coordinate" class="coordinate">

--- a/src/data/map_definitions.json
+++ b/src/data/map_definitions.json
@@ -10,7 +10,11 @@
     ],
     "patchDate": "2024-08-12",
     "seed": "78633191",
-    "tileSets": ["middle", "left", "right"]
+    "tileSets": [
+      "middle",
+      "left",
+      "right"
+    ]
   },
   {
     "key": "new-game-plus-main-branch",
@@ -23,7 +27,11 @@
     ],
     "patchDate": "2024-08-12",
     "seed": "78633191",
-    "tileSets": ["middle", "left", "right"]
+    "tileSets": [
+      "middle",
+      "left",
+      "right"
+    ]
   },
   {
     "key": "nightmare-main-branch",
@@ -36,7 +44,11 @@
     ],
     "patchDate": "2024-08-12",
     "seed": "78633191",
-    "tileSets": ["middle", "left", "right"]
+    "tileSets": [
+      "middle",
+      "left",
+      "right"
+    ]
   },
   {
     "key": "apotheosis-beta-branch",
@@ -50,7 +62,11 @@
     ],
     "patchDate": "2024-08-12",
     "seed": "78633194",
-    "tileSets": ["middle", "left", "right"]
+    "tileSets": [
+      "middle",
+      "left",
+      "right"
+    ]
   },
   {
     "key": "regular-beta",
@@ -63,11 +79,15 @@
     ],
     "patchDate": "2024-08-12",
     "seed": "78633191",
-    "tileSets": ["middle", "left", "right"]
+    "tileSets": [
+      "middle",
+      "left",
+      "right"
+    ]
   },
   {
     "key": "purgatory",
-    "label": "Purgatory",
+    "label": "Purtagory",
     "badges": [
       {
         "label": "Mod",
@@ -77,7 +97,9 @@
     ],
     "patchDate": "2024-08-12",
     "seed": "78633191",
-    "tileSets": ["middle"],
+    "tileSets": [
+      "middle"
+    ],
     "modUrl": "https://github.com/Priskip/purgatory"
   },
   {
@@ -92,7 +114,9 @@
     ],
     "patchDate": "2024-08-12",
     "seed": "78633191",
-    "tileSets": ["middle"],
+    "tileSets": [
+      "middle"
+    ],
     "modUrl": "https://steamcommunity.com/sharedfiles/filedetails/?id=3032128572"
   },
   {
@@ -107,7 +131,9 @@
     ],
     "patchDate": "2024-08-12",
     "seed": "78633191",
-    "tileSets": ["middle"],
+    "tileSets": [
+      "middle"
+    ],
     "modUrl": "https://steamcommunity.com/sharedfiles/filedetails/?id=3032128572"
   },
   {
@@ -122,7 +148,9 @@
     ],
     "patchDate": "2024-08-12",
     "seed": "78633191",
-    "tileSets": ["middle"],
+    "tileSets": [
+      "middle"
+    ],
     "modUrl": "https://steamcommunity.com/sharedfiles/filedetails/?id=2263080245"
   },
   {
@@ -137,7 +165,9 @@
     ],
     "patchDate": "2024-08-12",
     "seed": "78633191",
-    "tileSets": ["middle"],
+    "tileSets": [
+      "middle"
+    ],
     "modUrl": "https://steamcommunity.com/sharedfiles/filedetails/?id=2263080245"
   },
   {
@@ -152,7 +182,9 @@
     ],
     "patchDate": "2024-08-12",
     "seed": "78633191",
-    "tileSets": ["middle"],
+    "tileSets": [
+      "middle"
+    ],
     "modUrl": "https://steamcommunity.com/sharedfiles/filedetails/?id=2554761457"
   },
   {
@@ -167,7 +199,9 @@
     ],
     "patchDate": "2024-08-12",
     "seed": "78633191",
-    "tileSets": ["middle"]
+    "tileSets": [
+      "middle"
+    ]
   },
   {
     "key": "biomemaprendered-main-branch",
@@ -181,7 +215,9 @@
     ],
     "patchDate": "2024-08-12",
     "seed": "78633191",
-    "tileSets": ["middle"]
+    "tileSets": [
+      "middle"
+    ]
   },
   {
     "key": "maptestdev",
@@ -195,6 +231,8 @@
     ],
     "patchDate": "2024-08-12",
     "seed": "78633191",
-    "tileSets": ["middle"]
+    "tileSets": [
+      "middle"
+    ]
   }
 ]

--- a/src/data_sources/overlays.ts
+++ b/src/data_sources/overlays.ts
@@ -290,6 +290,10 @@ export const initSpellSelector = () => {
     const spellSprite = document.createElement('img');
     spellSprite.src = `${spritePath}/${spell.sprite}`;
     spellSprite.classList.add('pixelated-image');
+    spellSprite.onerror = () => {
+      spellSprite.src = './assets/icons/spells/missing.png'; // fallback image
+      spellSprite.alt = 'Missing';
+    };
     spellListItem.appendChild(spellSprite);
 
     const infoDiv = document.createElement('div');

--- a/src/nav.ts
+++ b/src/nav.ts
@@ -1,5 +1,6 @@
 import { getAllMapDefinitions } from './data_sources/map_definitions';
 import { assertElementById, formatDate } from './util';
+import type { MapDefinition } from './data_sources/map_definitions';
 
 export const NAV_LINK_IDENTIFIER = 'nav-link';
 
@@ -53,4 +54,10 @@ export const createMapLinks = (): HTMLUListElement => {
   }
 
   return navLinksUl;
+};
+
+// Utility to get short map name for selection
+export const getShortMapName = (def: MapDefinition) => {
+  if (def.key === 'purgatory') return 'Purtagory';
+  return def.label;
 };


### PR DESCRIPTION
Restore spell search UI with images, add image fallback, and update 'Purgatory' map name to 'Purtagory'.

The spell search input and list elements were missing from `index.html`, preventing spell images from rendering. These elements have been re-added to restore the UI as seen in production.